### PR TITLE
Fix write default messages

### DIFF
--- a/core/spam.py
+++ b/core/spam.py
@@ -58,7 +58,7 @@ else:
 	]
 	# Создаём файл messages.txt и записываем стандартные сообщения для примера
 	with open(MESSAGES_PATH, "w", encoding="utf-8") as f:
-		f.writelines(messages)
+		f.writelines(f"{x}\n" for x in messages)
 
 # -------------------------------------------
 # Сохраняем введённые данные авторизации в файл auth.dat


### PR DESCRIPTION
В прошлом пулреквесте #9 добавил сохранение дефолтных сообщений в файл, если файла с сообщениями не было. Раньше дефолтные сообщения записывались так `hi23fuck5`, теперь каждое сообщение с новой строки, как и должно быть.
```
hi
2
3
fuck
5
```